### PR TITLE
Update README git clone instruction with --recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To build `gimbricate`, use git to download its source and cmake to build.
 You'll need a recent gcc >= v7.4.
 
 ```
-git clone https://github.com/ekg/gimbricate.git
+git clone --recursive https://github.com/ekg/gimbricate.git
 cd gimbricate
 cmake -H. -Bbuild && cmake --build build -- -j 4
 ```


### PR DESCRIPTION
The build instruction `cmake -H. -Bbuild && cmake --build build -- -j 4` fails unless gimbricate and it's submodules are cloned.

The build error in my case:
```
CMake Error at /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:2530 (message):
  No download info given for 'tayweeargs' and its source directory:

   /home/njagi/Software/gimbricate/deps/args

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * DOWNLOAD_COMMAND
   * URL
   * GIT_REPOSITORY
   * SVN_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
Call Stack (most recent call first):
  /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:3105 (_ep_add_download_command)
  CMakeLists.txt:48 (ExternalProject_Add)


CMake Error at /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:2530 (message):
  No download info given for 'gfakluge' and its source directory:

   /home/njagi/Software/gimbricate/deps/gfakluge

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * DOWNLOAD_COMMAND
   * URL
   * GIT_REPOSITORY
   * SVN_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
Call Stack (most recent call first):
  /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:3105 (_ep_add_download_command)
  CMakeLists.txt:56 (ExternalProject_Add)


CMake Error at /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:2530 (message):
  No download info given for 'gssw' and its source directory:

   /home/njagi/Software/gimbricate/deps/gssw

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * DOWNLOAD_COMMAND
   * URL
   * GIT_REPOSITORY
   * SVN_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
Call Stack (most recent call first):
  /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:3105 (_ep_add_download_command)
  CMakeLists.txt:69 (ExternalProject_Add)


CMake Error at /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:2530 (message):
  No download info given for 'bbhash' and its source directory:

   /home/njagi/Software/gimbricate/deps/BBHash

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * DOWNLOAD_COMMAND
   * URL
   * GIT_REPOSITORY
   * SVN_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
Call Stack (most recent call first):
  /gnu/store/nrsbv2df55abwji1gsb1ilf22n3rc1xa-cmake-3.13.1/share/cmake-3.13/Modules/ExternalProject.cmake:3105 (_ep_add_download_command)
  CMakeLists.txt:77 (ExternalProject_Add)


-- Configuring incomplete, errors occurred!
See also "/home/njagi/Software/gimbricate/build/CMakeFiles/CMakeOutput.log".
```

Build succeeds when gimbricate is cloned with `--recursive`