### PR TITLE
'perfectOverlaps' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## why this fork?
 
-In this fork of [gimbricate](https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
+In this fork of [gimbricate](https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork of gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
+
 ## installation
 
 To build `gimbricate`, use git to download its source and cmake to build.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-## why this fork?
+# gimbricate
 
-In this fork of [gimbricate](https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork of gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
+Corrects the overlaps in DNA sequence graphs by realigning sequence ends.
+
+Optionally outputs FASTA and PAF representing the GFAv1-format graph.
+
+## bad overlaps!
+
+Almost no overlap-based assembly methods produce correct [GFAv1](https://github.com/GFA-spec/GFA-spec) output.
+Invariably, some overlaps are incorrectly defined.
+(The major exception to this are De Bruijn assemblers, which have fixed length overlaps that are correct by definition.)
+In some methods (like [shasta](https://github.com/chanzuckerberg/shasta)), the overlaps are systematically slightly wrong, due to their derivation from run length encoded sequences.
+It can help to correct these, because it lets us "bluntify" the graph.
+This produces a graph in which each base in the graph exists on only one node, which is a desirable property for variation graph and other pangenomic reference models.
 
 ## installation
 
@@ -15,8 +26,25 @@ cmake -H. -Bbuild && cmake --build build -- -j 4
 
 By default, it builds into `bin/` in the directory root.
 
+## Correcting the overlaps with `gimbricate`
 
-## pangenome construction
+gimbricate reads a GFA and uses the CIGAR strings attached to L records to guide realignment of the ends of the sequences and the subsequent correction of the CIGAR strings on the overlaps. It takes the sum of CIGAR operation lengths in the cigar to determine how much sequence to realign. Then it realigns the appropriate ends of the Sequence records referred to by the Link record with GSSW.
+
+For instance, these link records might be approximately accurate:
+
+L       256     +       1072    +       11M
+L       1072    +       1074    +       20M
+L       110     +       1072    -       20M
+L       1072    -       1074    -       20M
+
+But realignment suggests that only 11bp of the last one match:
+
+L       256     +       1072    +       11M
+L       1072    +       1074    +       20M
+L       110     +       1072    -       20M
+L       1072    -       1074    -       9D11M9I
+
+## Pangenome construction
 
 `gimbricate` can also convert its GFA output to a combination of FASTA and PAF.
 These may then be fed into [`seqwish`](https://github.com/ekg/seqwish), which induces a variation graph including the original contigs as paths.
@@ -28,6 +56,19 @@ gimbricate -g h.gfa -n -p h.paf -f h.fasta >h.gimbry.gfa
 seqwish -s h.fasta -p h.paf -g h.seqwish.gfa
 ```
 
+Optional flag -P can be used when trying to bluntify a graph with already correct overlaps (such as those outputted by De Bruijn assemblers), skipping the time- and memory-consuming process of realignment.
+
+This would additionally compress the graph by adding alignments between the nodes:
+
+```
+gimbricate -g h.gfa -n -p h.paf -f h.fasta >h.gimbry.gfa
+minimap2 -cx asm20 -k 11 -w 1 -X h.fasta h.fasta >h.self.paf
+cat h.paf h.self.paf >h.self+.paf
+seqwish -s h.fasta -p h.self+.paf -g h.seqwish+.gfa
+```
+
+Note that this techinque can be extended to provide graph to graph alignment and pangenome assembly.
+All that we need to do is to concatenate together the gimbricate PAFs, FASTAs, and `minimap2` PAFs for the full collection of graphs, and then feed these to `seqwish`.
 
 ## segment name management
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,7 @@
-# gimbricate
+# why this fork?
 
-Corrects the overlaps in DNA sequence graphs by realigning sequence ends.
-
-Optionally outputs FASTA and PAF representing the GFAv1-format graph.
-
-## bad overlaps!
-
-Almost no overlap-based assembly methods produce correct [GFAv1](https://github.com/GFA-spec/GFA-spec) output.
-Invariably, some overlaps are incorrectly defined.
-(The major exception to this are De Bruijn assemblers, which have fixed length overlaps that are correct by definition.)
-In some methods (like [shasta](https://github.com/chanzuckerberg/shasta)), the overlaps are systematically slightly wrong, due to their derivation from run length encoded sequences.
-It can help to correct these, because it lets us "bluntify" the graph.
-This produces a graph in which each base in the graph exists on only one node, which is a desirable property for variation graph and other pangenomic reference models.
-
-## preliminaries
+In this fork of [gimbricate]((https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
+## installation
 
 To build `gimbricate`, use git to download its source and cmake to build.
 You'll need a recent gcc >= v7.4.

--- a/README.md
+++ b/README.md
@@ -4,40 +4,17 @@ In this fork of [gimbricate](https://github.com/ekg/gimbricate/) we commented ou
 
 ## installation
 
-To build `gimbricate`, use git to download its source and cmake to build.
+To build this fork of `gimbricate`, use git to download its source and cmake to build.
 You'll need a recent gcc >= v7.4.
 
 ```
-git clone --recursive https://github.com/ekg/gimbricate.git
+git clone --recursive https://github.com/eeg-ebe/gimbricate.git
 cd gimbricate
 cmake -H. -Bbuild && cmake --build build -- -j 4
 ```
 
 By default, it builds into `bin/` in the directory root.
 
-## correcting the overlaps with `gimbricate`
-
-`gimbricate` reads a GFA and uses the CIGAR strings attached to `L` records to guide realignment of the ends of the sequences and the subsequent correction of the CIGAR strings on the overlaps.
-It takes the sum of CIGAR operation lengths in the cigar to determine how much sequence to realign.
-Then it realigns the appropriate ends of the `S`equence records referred to by the `L`ink record with [GSSW](https://github.com/vgteam/gssw).
-
-For instance, these link records might be approximately accurate:
-
-```
-L       256     +       1072    +       11M
-L       1072    +       1074    +       20M
-L       110     +       1072    -       20M
-L       1072    -       1074    -       20M
-```
-
-But realignment suggests that only 11bp of the last one match:
-
-```
-L       256     +       1072    +       11M
-L       1072    +       1074    +       20M
-L       110     +       1072    -       20M
-L       1072    -       1074    -       9D11M9I
-```
 
 ## pangenome construction
 
@@ -51,17 +28,6 @@ gimbricate -g h.gfa -n -p h.paf -f h.fasta >h.gimbry.gfa
 seqwish -s h.fasta -p h.paf -g h.seqwish.gfa
 ```
 
-While this would additionally compress it by adding alignments between the nodes:
-
-```
-gimbricate -g h.gfa -n -p h.paf -f h.fasta >h.gimbry.gfa
-minimap2 -cx asm20 -k 11 -w 1 -X h.fasta h.fasta >h.self.paf
-cat h.paf h.self.paf >h.self+.paf
-seqwish -s h.fasta -p h.self+.paf -g h.seqwish+.gfa
-```
-
-Note that this techinque can be extended to provide graph to graph alignment and pangenome assembly.
-All that we need to do is to concatenate together the gimbricate PAFs, FASTAs, and `minimap2` PAFs for the full collection of graphs, and then feed these to `seqwish`.
 
 ## segment name management
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In this fork of [gimbricate](https://github.com/ekg/gimbricate/) we commented ou
 ## installation
 
 To build this fork of `gimbricate`, use git to download its source and cmake to build.
-You'll need a recent gcc >= v7.4.
+You'll need a recent gcc >= v7.4 as well as cmake >= v3.1
 
 ```
 git clone --recursive https://github.com/eeg-ebe/gimbricate.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# why this fork?
+## why this fork?
 
 In this fork of [gimbricate]((https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
 ## installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## why this fork?
 
-In this fork of [gimbricate]((https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
+In this fork of [gimbricate](https://github.com/ekg/gimbricate/) we commented out the code for realigning overlaps (see this [discussion](https://github.com/ekg/gimbricate/issues/2)). Hence, this version of gimbricate should only be used when dealing with perfect overlaps, such as the ones produced by [Bwise](https://github.com/Malfoy/BWISE). Here the idea is to run first the present fork gimbricate on the GFA outputted by Bwise in order to generate a FASTA and a PAF, then run [seqwish](https://github.com/ekg/seqwish) on the FASTA and PAF in order to generate a GFA without any overlap. The original version of gimbricate seqfaulted on the large overlaps produced by Bwise, which is why we created this fork.
 ## installation
 
 To build `gimbricate`, use git to download its source and cmake to build.

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1,5 +1,8 @@
 #include "align.hpp"
+#include <iostream>
+#include <fstream>
 
+using std::endl;
 namespace gimbricate {
 
 std::string align_ends(const std::string& seq_x_full, const std::string& seq_y_full,
@@ -26,53 +29,20 @@ std::string align_ends(const std::string& seq_x_full, const std::string& seq_y_f
         seq_y = seq_y_full.substr(0, length);
     }
     
-    int8_t match = 1, mismatch = 4;
-    uint8_t gap_open = 6, gap_extension = 1;
-
-	/* This table is used to transform nucleotide letters into numbers. */
-    int8_t* nt_table = gssw_create_nt_table();
-    
-	// initialize scoring matrix for genome sequences
-	//  A  C  G  T	N (or other ambiguous code)
-	//  2 -2 -2 -2 	0	A
-	// -2  2 -2 -2 	0	C
-	// -2 -2  2 -2 	0	G
-	// -2 -2 -2  2 	0	T
-	//	0  0  0  0  0	N (or other ambiguous code)
-    int8_t* mat = gssw_create_score_matrix(match, mismatch);
-
-    gssw_node* node = (gssw_node*)gssw_node_create(NULL, 1, seq_x.c_str(), nt_table, mat);
-    gssw_graph* graph = gssw_graph_create(1);
-    gssw_graph_add_node(graph, node);
-
-    int8_t fl_bonus = 5; // try 63 to force full length alignment
-    gssw_graph_fill(graph, seq_y.c_str(), nt_table, mat, gap_open, gap_extension, fl_bonus, fl_bonus, 15, 2, true);
-
-    gssw_graph_mapping* gm = gssw_graph_trace_back (graph,
-                                                    seq_y.c_str(),
-                                                    seq_y.length(),
-                                                    nt_table,
-                                                    mat,
-                                                    gap_open,
-                                                    gap_extension,
-                                                    fl_bonus, fl_bonus);
-
-    
     //gssw_print_graph_mapping(gm, stdout);
-    std::string final_cigar = overlap_cigar(gm);
-    basic_cigar = simple_cigar(gm);
+    basic_cigar = std::to_string(length)+'M';
 
-    // determine the start and end of the alignment in the target and query
-    mapping_boundaries(gm,
-                       query_start, query_end,
-                       target_start, target_end,
-                       num_matches);
+    query_start = 0;
+    query_end = length;
+    target_start = seq_x_full.length()-length;
+    target_end = seq_x_full.length();
+    num_matches = length;
 
     // correct back to the coordinates of the full sequence
-    query_start += seq_y_offset;
-    query_end += seq_y_offset;
-    target_start += seq_x_offset;
-    target_end += seq_x_offset;
+//    query_start += seq_y_offset;
+//    query_end += seq_y_offset;
+//    target_start += seq_x_offset;
+//    target_end += seq_x_offset;
 
     // then invert the coordinates in the case that the pieces are inverted
     if (!seq_y_forward) {
@@ -88,16 +58,7 @@ std::string align_ends(const std::string& seq_x_full, const std::string& seq_y_f
         target_end = i;
     }
 
-    // clean up
-    gssw_graph_mapping_destroy(gm);
-
-    // note that nodes which are referred to in this graph are destroyed as well
-    gssw_graph_destroy(graph);
-
-    free(nt_table);
-	free(mat);
-
-    return final_cigar;
+    return std::to_string(length)+'M';
 }
 
 }

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -10,7 +10,7 @@ std::string align_ends(const std::string& seq_x_full, const std::string& seq_y_f
                        bool seq_x_forward, bool seq_y_forward,
                        uint64_t& query_start, uint64_t& query_end,
                        uint64_t& target_start, uint64_t& target_end,
-                       uint64_t& num_matches, std::string& basic_cigar) {
+                       uint64_t& num_matches, std::string& basic_cigar, bool perfectOverlaps) {
 
     // default parameters for genome sequence alignment
     std::string seq_x;
@@ -29,36 +29,111 @@ std::string align_ends(const std::string& seq_x_full, const std::string& seq_y_f
         seq_y = seq_y_full.substr(0, length);
     }
     
-    //gssw_print_graph_mapping(gm, stdout);
-    basic_cigar = std::to_string(length)+'M';
+    if (perfectOverlaps) {
 
-    query_start = 0;
-    query_end = length;
-    target_start = seq_x_full.length()-length;
-    target_end = seq_x_full.length();
-    num_matches = length;
+        //gssw_print_graph_mapping(gm, stdout);
+        basic_cigar = std::to_string(length)+'M';
 
-    // correct back to the coordinates of the full sequence
-//    query_start += seq_y_offset;
-//    query_end += seq_y_offset;
-//    target_start += seq_x_offset;
-//    target_end += seq_x_offset;
+        query_start = 0;
+        query_end = length;
+        target_start = seq_x_full.length()-length;
+        target_end = seq_x_full.length();
+        num_matches = length;
 
-    // then invert the coordinates in the case that the pieces are inverted
-    if (!seq_y_forward) {
-        uint64_t i = seq_y_full.length() - query_start;
-        uint64_t j = seq_y_full.length() - query_end;
-        query_start = j;
-        query_end = i;
+        // invert the coordinates in the case that the pieces are inverted
+        if (!seq_y_forward) {
+            uint64_t i = seq_y_full.length() - query_start;
+            uint64_t j = seq_y_full.length() - query_end;
+            query_start = j;
+            query_end = i;
+        }
+        if (!seq_x_forward) {
+            uint64_t i = seq_x_full.length() - target_start;
+            uint64_t j = seq_x_full.length() - target_end;
+            target_start = j;
+            target_end = i;
+        }
+
+        return std::to_string(length)+'M';
+
     }
-    if (!seq_x_forward) {
-        uint64_t i = seq_x_full.length() - target_start;
-        uint64_t j = seq_x_full.length() - target_end;
-        target_start = j;
-        target_end = i;
+
+    else{
+        int8_t match = 1, mismatch = 4;
+        uint8_t gap_open = 6, gap_extension = 1;
+
+            /* This table is used to transform nucleotide letters into numbers. */
+        int8_t* nt_table = gssw_create_nt_table();
+
+            // initialize scoring matrix for genome sequences
+            //  A  C  G  T	N (or other ambiguous code)
+            //  2 -2 -2 -2 	0	A
+            // -2  2 -2 -2 	0	C
+            // -2 -2  2 -2 	0	G
+            // -2 -2 -2  2 	0	T
+            //	0  0  0  0  0	N (or other ambiguous code)
+        int8_t* mat = gssw_create_score_matrix(match, mismatch);
+
+        gssw_node* node = (gssw_node*)gssw_node_create(NULL, 1, seq_x.c_str(), nt_table, mat);
+        gssw_graph* graph = gssw_graph_create(1);
+        gssw_graph_add_node(graph, node);
+
+        int8_t fl_bonus = 5; // try 63 to force full length alignment
+        gssw_graph_fill(graph, seq_y.c_str(), nt_table, mat, gap_open, gap_extension, fl_bonus, fl_bonus, 15, 2, true);
+
+        gssw_graph_mapping* gm = gssw_graph_trace_back (graph,
+                                                        seq_y.c_str(),
+                                                        seq_y.length(),
+                                                        nt_table,
+                                                        mat,
+                                                        gap_open,
+                                                        gap_extension,
+                                                        fl_bonus, fl_bonus);
+
+
+        //gssw_print_graph_mapping(gm, stdout);
+        std::string final_cigar = overlap_cigar(gm);
+        basic_cigar = simple_cigar(gm);
+
+        // determine the start and end of the alignment in the target and query
+        mapping_boundaries(gm,
+                           query_start, query_end,
+                           target_start, target_end,
+                           num_matches);
+
+        // correct back to the coordinates of the full sequence
+        query_start += seq_y_offset;
+        query_end += seq_y_offset;
+        target_start += seq_x_offset;
+        target_end += seq_x_offset;
+
+        // then invert the coordinates in the case that the pieces are inverted
+        if (!seq_y_forward) {
+            uint64_t i = seq_y_full.length() - query_start;
+            uint64_t j = seq_y_full.length() - query_end;
+            query_start = j;
+            query_end = i;
+        }
+        if (!seq_x_forward) {
+            uint64_t i = seq_x_full.length() - target_start;
+            uint64_t j = seq_x_full.length() - target_end;
+            target_start = j;
+            target_end = i;
+        }
+
+        // clean up
+        gssw_graph_mapping_destroy(gm);
+
+        // note that nodes which are referred to in this graph are destroyed as well
+        gssw_graph_destroy(graph);
+
+        free(nt_table);
+            free(mat);
+
+        return final_cigar;
     }
 
-    return std::to_string(length)+'M';
+
 }
 
 }

--- a/src/align.hpp
+++ b/src/align.hpp
@@ -15,7 +15,8 @@ std::string align_ends(const std::string& seq_x_full,
                        uint64_t& query_start, uint64_t& query_end,
                        uint64_t& target_start, uint64_t& target_end,
                        uint64_t& num_matches,
-                       std::string& basic_cigar);
+                       std::string& basic_cigar,
+                       bool perfectOverlaps);
 
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<double> expand_align(parser, "N", "expand the alignment length by this ratio (default 2.0)", {'e', "expand-align"});
     args::Flag no_rename(parser, "no-rename", "don't rename sequences to have increasing non-0 integer ids", {'n', "no-rename"});
     args::ValueFlag<std::string> prefix_names(parser, "PREFIX", "add this prefix to each sequence name", {'x', "name-prefix"});
+    args::Flag prfctOverlaps(parser, "perfectOverlaps", "use if the overlaps of the gfa are already exact and contain only matches", {'P', "perfectOverlaps"});
     args::Flag debug(parser, "debug", "enable debugging", {'d', "debug"});
     try {
         parser.ParseCLI(argc, argv);
@@ -98,6 +99,7 @@ int main(int argc, char** argv) {
     std::cout << "H\tVN:Z:1.0" << std::endl;
     auto min_read_cov = args::get(read_cov_min);
     bool rename_seqs = !args::get(no_rename);
+    bool perfectOverlaps = args::get(prfctOverlaps);
     std::string name_prefix = args::get(prefix_names);
     uint64_t id = 1;
     gg.for_each_sequence_line_in_file(filename, [&](gfak::sequence_elem s) {
@@ -163,7 +165,8 @@ int main(int argc, char** argv) {
                                          e.sink_orientation_forward,
                                          query_start, query_end,
                                          target_start, target_end,
-                                         num_matches, basic_cigar);
+                                         num_matches, basic_cigar,
+                                         perfectOverlaps);
                 std::cout << e.to_string_1() << std::endl;
                 if (write_paf) {
                     paf_row_t paf;


### PR DESCRIPTION
Created a 'perfectOverlaps' mode with the flag -P.
Useful when using gimbricate+seqwish to get rid of overlaps, but when the overlaps are already exact (when the assembly comes from a De Bruijn assembler, typically). On perfectOverlaps mode, gimbricate does not recompute the overlaps. See issue #2 .